### PR TITLE
ci: add security scanning (zizmor + trufflehog) and harden workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,12 +6,18 @@ on:
       - 'go.mod'
       - '**/*.go'
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
         with:
           version: v2.12.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,20 +5,20 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-  packages: write
+permissions: {}
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       version: ${{ steps.release.outputs.version }}
       major: ${{ steps.release.outputs.major }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:
           config-file: release-please-config.json
@@ -28,16 +28,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
+    permissions:
+      contents: write
+      packages: write
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/login-action@v4
+      # persist-credentials is required: the "Update major version tag" step
+      # pushes the tag using the checkout-persisted token.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           push: true
@@ -46,6 +51,8 @@ jobs:
             ghcr.io/keitap/github-asana-request-review-action:${{ needs.release-please.outputs.version }}
             ghcr.io/keitap/github-asana-request-review-action:latest
       - name: Update major version tag
+        env:
+          MAJOR: ${{ needs.release-please.outputs.major }}
         run: |
-          git tag -f "v${{ needs.release-please.outputs.major }}"
-          git push origin "v${{ needs.release-please.outputs.major }}" --force
+          git tag -f "v${MAJOR}"
+          git push origin "v${MAJOR}" --force

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,36 @@
+name: security
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+
+  trufflehog:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: TruffleHog
+        uses: trufflesecurity/trufflehog@30d5bb91af1a771378349dbbb0c82129392acf70 # v3.95.6
+        with:
+          extra_args: --results=verified,unknown

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ on:
 # to avoid creating duplicate tasks.
 concurrency: ci-${{ github.ref }}
 
+permissions: {}
+
 jobs:
   go-test:
     runs-on: ubuntu-latest
@@ -34,8 +36,13 @@ jobs:
 
   action-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
       - name: Use local Dockerfile for testing
         run: yq '.runs.image = "Dockerfile"' -i action.yml
       - name: Self test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,13 @@ permissions: {}
 jobs:
   go-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
       - name: Run Go tests

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  artipacked:
+    ignore:
+      # The publish job's checkout must keep its credentials so the
+      # "Update major version tag" step can push the tag.
+      - release.yml


### PR DESCRIPTION
## What

Add a `security` workflow and harden the existing workflows so they pass it.

### New `security.yml`
- **zizmor** (`zizmorcore/zizmor-action`) — static analysis of the GitHub Actions workflows, uploads SARIF to code scanning.
- **TruffleHog** (`trufflesecurity/trufflehog`) — secret scanning over the repository.
- Runs on push to `main` and on pull requests.

### Hardening (to pass zizmor)
- **Pin all actions to full commit SHAs** with `# vX` comments (Dependabot keeps the SHA + comment updated) — fixes `unpinned-uses`.
- **Minimal `permissions:`** — workflow-level `permissions: {}` plus per-job scopes (e.g. release-please: `contents`/`pull-requests`; publish: `contents`/`packages`) — fixes `excessive-permissions`.
- **`persist-credentials: false`** on checkouts that don't push.
- **`env`-passed major version** in the release tag step — fixes `template-injection`.
- **`.github/zizmor.yml`** ignores `artipacked` for `release.yml` only, because the publish checkout must keep credentials to push the major version tag.

## Verification

Local `zizmor --no-online-audits .github/workflows/` → **No findings** (1 intentional ignore, rest suppressed by persona).

## Note

`release.yml`/`lint.yml`/`test.yml` here are based on `main`. The `go-test`/`action-test` change is in PR #25; once both land, any new action refs it adds should also be SHA-pinned (Dependabot will otherwise propose it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)