### PR TITLE
ci: add govulncheck workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,21 @@
+name: govulncheck
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: {}
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - id: govulncheck
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          go-version-file: go.mod
+          repo-checkout: true


### PR DESCRIPTION
## What

Add `.github/workflows/govulncheck.yml` that runs [`golang/govulncheck-action`](https://github.com/golang/govulncheck-action) on push to `main` and on pull requests.

## Why

govulncheck fills a gap not covered by the existing tooling:
- Dependabot → dependency version bumps
- zizmor → workflow security
- TruffleHog → secrets
- golangci-lint (gosec) → general Go SAST

govulncheck detects known CVEs in Go modules and the standard library, and is call-graph aware, so it only reports vulnerabilities that are actually reachable from this code (low noise).

## Notes

- The action is SHA-pinned (`# v1.0.4`, Dependabot keeps it updated) and runs with `permissions: contents: read`; it handles checkout and Go setup itself (Go version from `go.mod`).
- Added as a standalone workflow to avoid conflicting with the open PRs that touch `test.yml` (#25) and `security.yml` (#26); it could be folded into `security.yml` later.
- Verified locally: `govulncheck ./...` on `main` reports **No vulnerabilities found**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)