### PR TITLE
test: skip Asana integration tests only when explicitly requested

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,9 @@ jobs:
         run: go test ./...
         env:
           ASANA_TOKEN: "${{ secrets.ASANA_TOKEN }}"
+          # Dependabot runs have no access to secrets, so skip the Asana
+          # integration tests there instead of failing on the missing token.
+          SKIP_INTEGRATION_TEST: ${{ github.actor == 'dependabot[bot]' && 'true' || '' }}
 
   action-test:
     runs-on: ubuntu-latest

--- a/account_test.go
+++ b/account_test.go
@@ -22,6 +22,8 @@ func TestNewNoAsanaAccount(t *testing.T) {
 }
 
 func TestNewFromUserTaskListGID(t *testing.T) {
+	requireAsanaToken(t)
+
 	c := asana.NewClientWithAccessToken(asanaToken)
 
 	a, err := NewAccount(c, asanaUserGID, "keitap")

--- a/asana_test.go
+++ b/asana_test.go
@@ -40,6 +40,22 @@ func init() {
 	asanaToken = os.Getenv("ASANA_TOKEN")
 }
 
+// requireAsanaToken guards tests that hit the live Asana API. It skips only
+// when SKIP_INTEGRATION_TEST is explicitly set (e.g. Dependabot runs, which
+// have no access to secrets); otherwise a missing token fails loudly so a
+// misconfigured secret is not silently treated as a pass.
+func requireAsanaToken(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv("SKIP_INTEGRATION_TEST") == "true" {
+		t.Skip("SKIP_INTEGRATION_TEST is set; skipping Asana integration test")
+	}
+
+	if asanaToken == "" {
+		t.Fatal("ASANA_TOKEN is not set (set SKIP_INTEGRATION_TEST=true to skip integration tests)")
+	}
+}
+
 func createTask() string {
 	if taskID != "" {
 		return taskID
@@ -169,6 +185,8 @@ func TestBuildReviewCommentHTML(t *testing.T) {
 }
 
 func TestAddPullRequestCommentToTask(t *testing.T) {
+	requireAsanaToken(t)
+
 	c := asana.NewClientWithAccessToken(asanaToken)
 
 	pr := loadRequestReviewRequestedEvent()
@@ -180,6 +198,8 @@ func TestAddPullRequestCommentToTask(t *testing.T) {
 }
 
 func TestFindTaskComment(t *testing.T) {
+	requireAsanaToken(t)
+
 	c := asana.NewClientWithAccessToken(asanaToken)
 
 	tests := []struct {
@@ -200,6 +220,8 @@ func TestFindTaskComment(t *testing.T) {
 }
 
 func TestUpdateTaskComment(t *testing.T) {
+	requireAsanaToken(t)
+
 	c := asana.NewClientWithAccessToken(asanaToken)
 
 	pr := loadRequestReviewRequestedEvent()
@@ -209,6 +231,8 @@ func TestUpdateTaskComment(t *testing.T) {
 }
 
 func TestCodeReviewSubtask(t *testing.T) {
+	requireAsanaToken(t)
+
 	c := asana.NewClientWithAccessToken(asanaToken)
 
 	var subtask *asana.Task
@@ -245,6 +269,8 @@ func TestCodeReviewSubtask(t *testing.T) {
 }
 
 func TestFindSubtaskByName(t *testing.T) {
+	requireAsanaToken(t)
+
 	c := asana.NewClientWithAccessToken(asanaToken)
 
 	pr := loadRequestReviewRequestedEvent()

--- a/handler_test.go
+++ b/handler_test.go
@@ -42,6 +42,8 @@ func pInt(i int) *int {
 }
 
 func TestHandler_handlePullRequestEvent(t *testing.T) {
+	requireAsanaToken(t)
+
 	conf := &Config{
 		Accounts: map[GithubLogin]AsanaGID{
 			"keitap":     "5590853215184",
@@ -59,6 +61,8 @@ func TestHandler_handlePullRequestEvent(t *testing.T) {
 }
 
 func TestHandler_handlePullRequestEvent_NoConfig(t *testing.T) {
+	requireAsanaToken(t)
+
 	conf := &Config{}
 
 	ac := asana.NewClientWithAccessToken(asanaToken)
@@ -71,6 +75,8 @@ func TestHandler_handlePullRequestEvent_NoConfig(t *testing.T) {
 }
 
 func TestHandler_getAssigneeOrRequester(t *testing.T) {
+	requireAsanaToken(t)
+
 	conf := &Config{
 		Accounts: map[GithubLogin]AsanaGID{
 			"keitap":     "5590853215184",


### PR DESCRIPTION
## Problem

The `go-test` job fails on Dependabot PRs (e.g. #24) with `401: Not Authorized` from Asana, because GitHub does not expose secrets to Dependabot runs, so `ASANA_TOKEN` is empty and the integration tests that hit the live Asana API panic.

## Fix

Add `requireAsanaToken(t)` to the tests that call the Asana API (`asana_test.go`, `account_test.go`, `handler_test.go`). Its behavior is fail-safe:

- `SKIP_INTEGRATION_TEST=true` → **skip** (explicit, intentional).
- otherwise, missing `ASANA_TOKEN` → **fail** with a clear message.

This deliberately distinguishes an *intentional* secret-less run (Dependabot) from an *accidental* misconfiguration (a trusted run that should have the secret but doesn't) — the latter fails loudly instead of silently skipping.

The `go-test` job sets `SKIP_INTEGRATION_TEST` only for `dependabot[bot]`:

```yaml
SKIP_INTEGRATION_TEST: ${{ github.actor == 'dependabot[bot]' && 'true' || '' }}
```

Pure unit tests (escaping, dates, parsing, config) are unguarded and always run, so Dependabot PRs still compile the whole module (catching breaking dependency API changes) and run the unit tests.

## Verification (local)

- `SKIP_INTEGRATION_TEST=true`, no token → integration skipped, unit tests pass.
- no token, no flag → fails with `ASANA_TOKEN is not set (...)`.
- token present → integration tests run and pass.

Note: fork PRs (also secret-less) are intentionally not handled; this repo does not accept fork contributions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)