### PR TITLE
fix: paginate story and subtask search to prevent duplicate comments

### DIFF
--- a/asana.go
+++ b/asana.go
@@ -43,22 +43,31 @@ func AddPullRequestCommentToTask(client *asana.Client, taskID string, requester 
 }
 
 // FindTaskComment finds a story which contains specified string.
+// Stories include every activity event (field changes, likes, etc.), not just
+// comments, and the API returns them oldest first. Busy tasks easily exceed
+// one page, so all pages must be scanned before concluding there is no match.
 func FindTaskComment(client *asana.Client, taskID string, findString string) (*asana.Story, error) {
 	task := &asana.Task{ID: taskID}
-	stories, _, err := task.Stories(client, &asana.Options{
-		Limit: 100,
-	})
-	if err != nil {
-		return nil, err
-	}
+	opts := &asana.Options{Limit: 100}
 
-	for _, s := range stories {
-		if strings.Contains(s.Text, findString) {
-			return s, nil
+	for {
+		stories, nextPage, err := task.Stories(client, opts)
+		if err != nil {
+			return nil, err
 		}
-	}
 
-	return nil, nil
+		for _, s := range stories {
+			if strings.Contains(s.Text, findString) {
+				return s, nil
+			}
+		}
+
+		if nextPage == nil || nextPage.Offset == "" {
+			return nil, nil
+		}
+
+		opts.Offset = nextPage.Offset
+	}
 }
 
 func UpdateTaskComment(client *asana.Client, storyID string, requester *Account, pr *github.PullRequestEvent) (*asana.Story, error) {
@@ -97,23 +106,29 @@ func UpdateCodeReviewSubtask(client *asana.Client, subtask *asana.Task, requeste
 }
 
 // FindSubtaskByName finds a subtask which contains specified string.
+// Subtasks are paginated the same way as stories, so scan all pages.
 func FindSubtaskByName(client *asana.Client, taskID string, findString string) (*asana.Task, error) {
 	task := &asana.Task{ID: taskID}
+	opts := &asana.Options{Limit: 100}
 
-	subtasks, _, err := task.Subtasks(client, &asana.Options{
-		Limit: 100,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	for _, s := range subtasks {
-		if strings.Contains(s.Name, findString) {
-			return s, nil
+	for {
+		subtasks, nextPage, err := task.Subtasks(client, opts)
+		if err != nil {
+			return nil, err
 		}
-	}
 
-	return nil, nil
+		for _, s := range subtasks {
+			if strings.Contains(s.Name, findString) {
+				return s, nil
+			}
+		}
+
+		if nextPage == nil || nextPage.Offset == "" {
+			return nil, nil
+		}
+
+		opts.Offset = nextPage.Offset
+	}
 }
 
 func buildReviewCommentHTML(reviewURL string, reviewState string, reviewerPermalink string, reviewBody string, commentCount int) string {

--- a/asana_test.go
+++ b/asana_test.go
@@ -1,6 +1,11 @@
 package githubasana
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -217,6 +222,119 @@ func TestFindTaskComment(t *testing.T) {
 			assert.Equal(t, test.expected, story != nil)
 		})
 	}
+}
+
+// newFakeAsanaClient returns a client pointed at a local fake Asana API.
+func newFakeAsanaClient(t *testing.T, handler http.Handler) *asana.Client {
+	t.Helper()
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	c := asana.NewClient(srv.Client())
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	c.BaseURL = u
+
+	return c
+}
+
+func writeAsanaPage(t *testing.T, w http.ResponseWriter, data any, nextOffset string) {
+	t.Helper()
+
+	resp := map[string]any{"data": data}
+	if nextOffset != "" {
+		resp["next_page"] = map[string]string{"offset": nextOffset}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(w).Encode(resp))
+}
+
+// TestFindTaskCommentAcrossPages reproduces the duplicate comment incident:
+// the stories endpoint returns entries oldest first, so on a task with more
+// than 100 stories the bot's comment only appears on a later page.
+func TestFindTaskCommentAcrossPages(t *testing.T) {
+	fillerPage := make([]map[string]string, 100)
+	for i := range fillerPage {
+		fillerPage[i] = map[string]string{"gid": fmt.Sprintf("sys-%d", i), "text": "changed the due date"}
+	}
+
+	tests := []struct {
+		name       string
+		secondPage []map[string]string
+		expectedID string
+	}{
+		{
+			name: "comment on second page is found",
+			secondPage: []map[string]string{
+				{"gid": "story-101", "text": "PR comment\n\n" + signature},
+			},
+			expectedID: "story-101",
+		},
+		{
+			name:       "no comment on any page",
+			secondPage: []map[string]string{{"gid": "sys-101", "text": "liked the task"}},
+			expectedID: "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/tasks/42/stories", func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Query().Get("offset") {
+				case "":
+					writeAsanaPage(t, w, fillerPage, "page2")
+				case "page2":
+					writeAsanaPage(t, w, test.secondPage, "")
+				default:
+					http.Error(w, "unexpected offset", http.StatusBadRequest)
+				}
+			})
+
+			c := newFakeAsanaClient(t, mux)
+
+			story, err := FindTaskComment(c, "42", signature)
+			require.NoError(t, err)
+
+			if test.expectedID == "" {
+				assert.Nil(t, story)
+			} else {
+				require.NotNil(t, story)
+				assert.Equal(t, test.expectedID, story.ID)
+			}
+		})
+	}
+}
+
+func TestFindSubtaskByNameAcrossPages(t *testing.T) {
+	fillerPage := make([]map[string]string, 100)
+	for i := range fillerPage {
+		fillerPage[i] = map[string]string{"gid": fmt.Sprintf("sub-%d", i), "name": fmt.Sprintf("subtask %d", i)}
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tasks/42/subtasks", func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("offset") {
+		case "":
+			writeAsanaPage(t, w, fillerPage, "page2")
+		case "page2":
+			writeAsanaPage(t, w, []map[string]string{
+				{"gid": "sub-101", "name": "✍️ Code review: #123 Keita Kitamura (@keitap)"},
+			}, "")
+		default:
+			http.Error(w, "unexpected offset", http.StatusBadRequest)
+		}
+	})
+
+	c := newFakeAsanaClient(t, mux)
+
+	subtask, err := FindSubtaskByName(c, "42", "@keitap")
+	require.NoError(t, err)
+	require.NotNil(t, subtask)
+	assert.Equal(t, "sub-101", subtask.ID)
 }
 
 func TestUpdateTaskComment(t *testing.T) {


### PR DESCRIPTION
## Problem

`FindTaskComment` and `FindSubtaskByName` fetched only the first page
(`Limit: 100`) of results and never followed the `NextPage` cursor.

Asana returns stories and subtasks **oldest-first**, and "stories"
include every activity event on a task (field changes, likes,
assignments, subtask creation, …), not just comments. Once a task
accumulates more than 100 stories, the bot's own upsert-target comment is
pushed past the first page. The lookup then always returns "not found",
so the handler creates a **new duplicate comment on every
`pull_request` event** instead of updating the existing one.

`FindSubtaskByName` had the identical single-page limitation.

## Fix

Follow the `NextPage` offset until it is empty, scanning every page
before concluding there is no match. The first match (oldest) is
returned, so the upsert target stays deterministic across events.

## Tests

Added unit tests backed by a local fake Asana API (`httptest`) that
reproduce the across-pages lookup for both functions. The first page
returns 100 non-matching activity entries and the match only appears on
the second page — this fails against the old single-page code and passes
with the fix. No live Asana token is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)